### PR TITLE
Use default media player device classes for vizio component (#30802)

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -782,7 +782,9 @@ omit =
     homeassistant/components/viaggiatreno/sensor.py
     homeassistant/components/vicare/*
     homeassistant/components/vivotek/camera.py
-    homeassistant/components/vizio/*
+    homeassistant/components/vizio/__init__.py
+    homeassistant/components/vizio/const.py
+    homeassistant/components/vizio/media_player.py
     homeassistant/components/vlc/media_player.py
     homeassistant/components/vlc_telnet/media_player.py
     homeassistant/components/volkszaehler/sensor.py

--- a/homeassistant/components/vizio/__init__.py
+++ b/homeassistant/components/vizio/__init__.py
@@ -1,48 +1,29 @@
 """The vizio component."""
+import asyncio
+
 import voluptuous as vol
 
+from homeassistant.components.media_player import DEVICE_CLASS_TV
 from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
-from homeassistant.const import (
-    CONF_ACCESS_TOKEN,
-    CONF_DEVICE_CLASS,
-    CONF_HOST,
-    CONF_NAME,
-)
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_DEVICE_CLASS
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType, HomeAssistantType
 
-from .const import (
-    CONF_VOLUME_STEP,
-    DEFAULT_DEVICE_CLASS,
-    DEFAULT_NAME,
-    DEFAULT_VOLUME_STEP,
-    DOMAIN,
-)
+from .const import DOMAIN, VIZIO_SCHEMA
 
 
 def validate_auth(config: ConfigType) -> ConfigType:
-    """Validate presence of CONF_ACCESS_TOKEN when CONF_DEVICE_CLASS=tv."""
+    """Validate presence of CONF_ACCESS_TOKEN when CONF_DEVICE_CLASS == DEVICE_CLASS_TV."""
     token = config.get(CONF_ACCESS_TOKEN)
-    if config[CONF_DEVICE_CLASS] == "tv" and not token:
+    if config[CONF_DEVICE_CLASS] == DEVICE_CLASS_TV and not token:
         raise vol.Invalid(
-            f"When '{CONF_DEVICE_CLASS}' is 'tv' then '{CONF_ACCESS_TOKEN}' is required.",
+            f"When '{CONF_DEVICE_CLASS}' is '{DEVICE_CLASS_TV}' then "
+            f"'{CONF_ACCESS_TOKEN}' is required.",
             path=[CONF_ACCESS_TOKEN],
         )
 
     return config
 
-
-VIZIO_SCHEMA = {
-    vol.Required(CONF_HOST): cv.string,
-    vol.Optional(CONF_ACCESS_TOKEN): cv.string,
-    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
-    vol.Optional(CONF_DEVICE_CLASS, default=DEFAULT_DEVICE_CLASS): vol.All(
-        cv.string, vol.Lower, vol.In(["tv", "soundbar"])
-    ),
-    vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): vol.All(
-        vol.Coerce(int), vol.Range(min=1, max=10)
-    ),
-}
 
 CONFIG_SCHEMA = vol.Schema(
     {
@@ -52,6 +33,8 @@ CONFIG_SCHEMA = vol.Schema(
     },
     extra=vol.ALLOW_EXTRA,
 )
+
+PLATFORMS = ["media_player"]
 
 
 async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
@@ -69,15 +52,23 @@ async def async_setup(hass: HomeAssistantType, config: ConfigType) -> bool:
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Load the saved entities."""
-    hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "media_player")
-    )
+    for platform in PLATFORMS:
+        hass.async_create_task(
+            hass.config_entries.async_forward_entry_setup(entry, platform)
+        )
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.config_entries.async_forward_entry_unload(entry, "media_player")
+    unload_ok = all(
+        await asyncio.gather(
+            *[
+                hass.config_entries.async_forward_entry_unload(entry, platform)
+                for platform in PLATFORMS
+            ]
+        )
+    )
 
-    return True
+    return unload_ok

--- a/homeassistant/components/vizio/const.py
+++ b/homeassistant/components/vizio/const.py
@@ -1,11 +1,76 @@
 """Constants used by vizio component."""
+from datetime import timedelta
+
+from pyvizio.const import (
+    DEVICE_CLASS_SPEAKER as VIZIO_DEVICE_CLASS_SPEAKER,
+    DEVICE_CLASS_TV as VIZIO_DEVICE_CLASS_TV,
+)
+import voluptuous as vol
+
+from homeassistant.components.media_player import DEVICE_CLASS_SPEAKER, DEVICE_CLASS_TV
+from homeassistant.components.media_player.const import (
+    SUPPORT_NEXT_TRACK,
+    SUPPORT_PREVIOUS_TRACK,
+    SUPPORT_SELECT_SOURCE,
+    SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON,
+    SUPPORT_VOLUME_MUTE,
+    SUPPORT_VOLUME_SET,
+    SUPPORT_VOLUME_STEP,
+)
+from homeassistant.const import (
+    CONF_ACCESS_TOKEN,
+    CONF_DEVICE_CLASS,
+    CONF_HOST,
+    CONF_NAME,
+)
+import homeassistant.helpers.config_validation as cv
+
 CONF_VOLUME_STEP = "volume_step"
 
+DEFAULT_DEVICE_CLASS = DEVICE_CLASS_TV
 DEFAULT_NAME = "Vizio SmartCast"
 DEFAULT_VOLUME_STEP = 1
-DEFAULT_DEVICE_CLASS = "tv"
+
 DEVICE_ID = "pyvizio"
 
 DOMAIN = "vizio"
+ICON = {DEVICE_CLASS_TV: "mdi:television", DEVICE_CLASS_SPEAKER: "mdi:speaker"}
 
-ICON = {"tv": "mdi:television", "soundbar": "mdi:speaker"}
+COMMON_SUPPORTED_COMMANDS = (
+    SUPPORT_SELECT_SOURCE
+    | SUPPORT_TURN_ON
+    | SUPPORT_TURN_OFF
+    | SUPPORT_VOLUME_MUTE
+    | SUPPORT_VOLUME_SET
+    | SUPPORT_VOLUME_STEP
+)
+
+SUPPORTED_COMMANDS = {
+    DEVICE_CLASS_SPEAKER: COMMON_SUPPORTED_COMMANDS,
+    DEVICE_CLASS_TV: (
+        COMMON_SUPPORTED_COMMANDS | SUPPORT_NEXT_TRACK | SUPPORT_PREVIOUS_TRACK
+    ),
+}
+
+# Since Vizio component relies on device class, this dict will ensure that changes to
+# the values of DEVICE_CLASS_SPEAKER or DEVICE_CLASS_TV don't require changes to pyvizio.
+VIZIO_DEVICE_CLASSES = {
+    DEVICE_CLASS_SPEAKER: VIZIO_DEVICE_CLASS_SPEAKER,
+    DEVICE_CLASS_TV: VIZIO_DEVICE_CLASS_TV,
+}
+
+VIZIO_SCHEMA = {
+    vol.Required(CONF_HOST): cv.string,
+    vol.Optional(CONF_ACCESS_TOKEN): cv.string,
+    vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
+    vol.Optional(CONF_DEVICE_CLASS, default=DEFAULT_DEVICE_CLASS): vol.All(
+        cv.string, vol.Lower, vol.In([DEVICE_CLASS_TV, DEVICE_CLASS_SPEAKER])
+    ),
+    vol.Optional(CONF_VOLUME_STEP, default=DEFAULT_VOLUME_STEP): vol.All(
+        vol.Coerce(int), vol.Range(min=1, max=10)
+    ),
+}
+
+MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
+MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)

--- a/homeassistant/components/vizio/strings.json
+++ b/homeassistant/components/vizio/strings.json
@@ -23,7 +23,7 @@
             "already_setup": "This entry has already been setup.",
             "host_exists": "Vizio component with host already configured.",
             "name_exists": "Vizio component with name already configured.",
-            "updated_volume_step": "This entry has already been setup but the volume step size in the config does not match the config entry so the config entry has been updated accordingly."
+            "updated_options": "This entry has already been setup but the options defined in the config do not match the previously imported options values so the config entry has been updated accordingly."
         }
     },
     "options": {
@@ -32,7 +32,8 @@
             "init": {
                 "title": "Update Vizo SmartCast Options",
                 "data": {
-                    "volume_step": "Volume Step Size"
+                    "volume_step": "Volume Step Size",
+                    "timeout": "API Request Timeout (seconds)"
                 }
             }
         }


### PR DESCRIPTION
* use media player defined device classes instead of custom ones, add options flow test, add timeout options parameter

* make options update error more generic

* fix config flow options update logic

* simplify logic for options update during import

* use platform list for load and unload

* update private config flow function name and description

* fix grammar in strings.json

* update mock config variable names to be more accurate

* remove timeout conf option, create device_class property

* update requirements

* update .coveragerc to indicate that config_flow has tests

* fix source of device_class property and move constants to const.py

* fix grammar in error message

* remove redundant device check in async_setup_entry since device connection is checked during config flow

* revert change to async_setup_entry, raise ConfigEntryNotReady if device can't be connected to

* update error text

* add more context to error text

## Breaking Change:

<!-- What is breaking and why we have to break it. Remove this section only if it was NOT a breaking change. -->

## Description:


**Related issue (if applicable):** fixes #<home-assistant issue number goes here>

**Pull request with documentation for [home-assistant.io](https://github.com/home-assistant/home-assistant.io) (if applicable):** home-assistant/home-assistant.io#<home-assistant.io PR number goes here>

## Example entry for `configuration.yaml` (if applicable):
```yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [ ] There is no commented out code in this PR.
  - [ ] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`.
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`.
  - [ ] Untested files have been added to `.coveragerc`.

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
